### PR TITLE
Runner feature turn response

### DIFF
--- a/lib/computer.rb
+++ b/lib/computer.rb
@@ -45,6 +45,22 @@ class Computer
     # The above will either return "Hit!" or "Miss!" from the fire_upon method in the cell class
   end
 
+  def chosen_coordinate
+    @fired_upon_coordinates.last
+  end
+
+  def shot_result(coordinate)
+    if @board.cells[coordinate].render == 'M'
+      "Miss!"
+    elsif @board.cells[coordinate].render == 'H'
+      "Hit!"
+    elsif @board.cells[coordinate].render == 'X'
+      "Hit, and sunk the ship!"
+    else
+      "Error"
+    end
+  end
+
   private
 
   def fired_upon_coordinate(chosen_coordinate_to_fire_upon) 

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -43,7 +43,7 @@ class Game
     cruiser_coordinates = gets.chomp.split(',')
 
     until_valid_placement(@player.cruiser, cruiser_coordinates)
-    # place_ship is being called in the below helper method
+    
     puts @player.board.render(true)
 
     puts "Enter the coordinates for the #{@player.submarine.name} (#{@player.submarine.length} spaces):"
@@ -56,22 +56,29 @@ class Game
   
   def turn
     both_boards_rendered
+
     puts "Your turn:"
     puts "Enter a coordinate to fire on"
     coordinate = gets.chomp.upcase
     @player.fire_upon_computer(coordinate, @computer.board)
-    # right now, both the computer and the player can win (if it comes down to the very last turn)
-    # perhaps we place a check in here to end the turn before player or computer can choose in the event they have been sunk
-    puts "My turn:"
+
+    ## Coordinate's render status can tell result
+    ## Call computer.board.cells[coordinate] render status
+    puts "Your shot on #{coordinate} was a #{@computer.shot_result(coordinate)}"
+
+    # this is a check to end the game before computer has another chance to fire, preventing tie scenario
+    if computer_ships_all_sunk?
+      return
+    else
+      nil
+    end
+
     @computer.fire_upon_player(@player.board)
-    # Also: it might be better if we use interpolation to say whether the shot was a "hit" or "miss".
-    # for some reason the final shot returns "miss" instead of a hit, even though that shot ends the game.
-    # MAYBE THIS IS HAPPENING BECAUSE THE FINAL SHOT DOES NOT REGISTER AS A HIT, BECAUSE IT IS CHANGING THE STATUS TO SUNK?
+    puts "My turn:"
+    puts "My shot on #{@computer.chosen_coordinate} was a _____"
   end
 
-  # results method gives different message based on which board has all sunken ships
   def results
-    # it might be nice to show the board at the end of the game, to look at
     puts "=🌊=🌊=🌊=🌊=🌊=🌊=🌊=🌊=🌊"
     puts "The results:"
     both_boards_rendered
@@ -103,7 +110,6 @@ class Game
     @player.board.place(ship, player_coordinates)
   end
 
-  # Create helper method to use for both_boards_rendered
   def both_boards_rendered
     computer_board_title = "COMPUTER BOARD".center(30, '=')
     puts computer_board_title
@@ -112,5 +118,4 @@ class Game
     puts player_board_title
     puts @player.board.render(true)    
   end
-  
 end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -75,7 +75,7 @@ class Game
 
     @computer.fire_upon_player(@player.board)
     puts "My turn:"
-    puts "My shot on #{@computer.chosen_coordinate} was a _____"
+    puts "My shot on #{@computer.chosen_coordinate} was a #{@player.shot_result(@computer.chosen_coordinate)}"
   end
 
   def results

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -25,6 +25,18 @@ class Player
     # The above will either return "Hit!" or "Miss!" from the fire_upon method in the cell class
   end
 
+   def shot_result(chosen_coordinate)
+    if @board.cells[chosen_coordinate].render == 'M'
+      "Miss!"
+    elsif @board.cells[chosen_coordinate].render == 'H'
+      "Hit!"
+    elsif @board.cells[chosen_coordinate].render == 'X'
+      "Hit, and sunk the ship!"
+    else
+      "Error"
+    end
+  end
+
   private 
 
   def fired_upon_coordinate(coordinate) 

--- a/runner.rb
+++ b/runner.rb
@@ -7,18 +7,16 @@ require './lib/game'
 require 'pry'
 
 loop do
-  # game variable within loop wipes board, fresh start
+
   game = Game.new
 
   game.menu
 
   game.setup
 
-  # this until block repeats the turn step until all of the ships on one board are sunk
   until game.player_ships_all_sunk? || game.computer_ships_all_sunk?
     game.turn
   end
 
   game.results
 end
-# do loop here there Y goes, game.setup -> game.turn loop -> game.results

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -7,6 +7,9 @@ require './lib/game'
 require 'pry'
 
 RSpec.describe Game do
+### Tests here verify things that can happen in isolation
+### Helpers that can prevent o v e r r e a c h i n g
+
   it 'holds player & computer' do
 
   end


### PR DESCRIPTION
Add a check during the game turn if all computer ships are sunk, preventing an opportunity for a tie.

Add a shot_result method to both the player and computer classes, which is how the text for shot result can get the status.

Other changes can _probably_ get ignored as I think they are deleting comments, etc.